### PR TITLE
Add local guess statistics and stats route

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.1.1",
-        "react-dom": "^19.1.1"
+        "react-dom": "^19.1.1",
+        "react-router-dom": "^6.30.1"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3.3.1",
@@ -1063,6 +1064,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.0.tgz",
+      "integrity": "sha512-O3rHJzAQKamUz1fvE0Qaw0xSFqsA/yafi2iqeE0pvdFtCO1viYx8QL6f3Ln/aCCTLxs68SLf0KPM9eSeM8yBnA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -5711,6 +5721,38 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.1.tgz",
+      "integrity": "sha512-X1m21aEmxGXqENEPG3T6u0Th7g0aS4ZmoNynhbs+Cn+q+QGTLt+d5IQ2bHAXKzKcxGJjxACpVbnYQSCRcfxHlQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.1",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.1.tgz",
+      "integrity": "sha512-llKsgOkZdbPU1Eg3zK8lCn+sjD9wMRZZPuzmdWWX5SUs8OFkN5HnFVC0u5KMeMaC9aoancFI/KoLuKPqN+hxHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@remix-run/router": "1.23.0",
+        "react-router": "6.30.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.1.1",
-    "react-dom": "^19.1.1"
+    "react-dom": "^19.1.1",
+    "react-router-dom": "^6.30.1"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.3.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,18 @@
-import logo from './assets/logo.png';
+import { Link, Route, Routes } from 'react-router-dom';
+import Home from './Home.tsx';
+import StatsPage from './StatsPage.tsx';
 
 function App() {
-
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#242424]">
-      <img src={logo} alt="Guess The Model logo" className="w-64" />
+    <div className="min-h-screen bg-[#242424] text-white">
+      <nav className="p-4">
+        <Link to="/" className="mr-4">Home</Link>
+        <Link to="/stats">Stats</Link>
+      </nav>
+      <Routes>
+        <Route path="/" element={<Home />} />
+        <Route path="/stats" element={<StatsPage />} />
+      </Routes>
     </div>
   );
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,0 +1,11 @@
+import logo from './assets/logo.png';
+
+function Home() {
+  return (
+    <div className="flex min-h-screen items-center justify-center">
+      <img src={logo} alt="Guess The Model logo" className="w-64" />
+    </div>
+  );
+}
+
+export default Home;

--- a/src/StatsPage.tsx
+++ b/src/StatsPage.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+import { getStats, clearStats } from './stats.ts';
+import type { Stats } from './stats.ts';
+
+function StatsPage() {
+  const [stats, setStats] = useState<Stats>(getStats());
+
+  useEffect(() => {
+    const update = () => setStats(getStats());
+    window.addEventListener('storage', update);
+    return () => window.removeEventListener('storage', update);
+  }, []);
+
+  return (
+    <div className="p-4 text-white">
+      <h1 className="mb-4 text-2xl">Statistics</h1>
+      <div className="mb-4">
+        <p>Total guesses: {stats.total}</p>
+        <p>Correct: {stats.correct}</p>
+        <p>Incorrect: {stats.incorrect}</p>
+      </div>
+      <h2 className="mb-2 text-xl">By Model</h2>
+      <ul className="mb-4">
+        {Object.entries(stats.models).map(([model, s]) => (
+          <li key={model} className="mb-2">
+            <span className="font-bold">{model}:</span> {s.correct} correct / {s.incorrect} incorrect (total {s.total})
+          </li>
+        ))}
+      </ul>
+      <button
+        type="button"
+        onClick={() => { clearStats(); setStats(getStats()); }}
+        className="rounded bg-blue-500 px-4 py-2 text-white"
+      >
+        Clear Stats
+      </button>
+    </div>
+  );
+}
+
+export default StatsPage;

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
 import './index.css';
 import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </StrictMode>,
 );

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -1,0 +1,55 @@
+export interface ModelStats {
+  correct: number;
+  incorrect: number;
+  total: number;
+}
+
+export interface Stats {
+  correct: number;
+  incorrect: number;
+  total: number;
+  models: Record<string, ModelStats>;
+}
+
+const STORAGE_KEY = 'stats';
+
+function getInitialStats(): Stats {
+  return {
+    correct: 0,
+    incorrect: 0,
+    total: 0,
+    models: {},
+  };
+}
+
+export function getStats(): Stats {
+  const raw = localStorage.getItem(STORAGE_KEY);
+  if (!raw) return getInitialStats();
+  try {
+    return JSON.parse(raw) as Stats;
+  } catch {
+    return getInitialStats();
+  }
+}
+
+export function recordGuess(model: string, isCorrect: boolean): void {
+  const stats = getStats();
+  if (!stats.models[model]) {
+    stats.models[model] = { correct: 0, incorrect: 0, total: 0 };
+  }
+  const modelStats = stats.models[model];
+  if (isCorrect) {
+    stats.correct += 1;
+    modelStats.correct += 1;
+  } else {
+    stats.incorrect += 1;
+    modelStats.incorrect += 1;
+  }
+  stats.total += 1;
+  modelStats.total += 1;
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
+}
+
+export function clearStats(): void {
+  localStorage.removeItem(STORAGE_KEY);
+}


### PR DESCRIPTION
## Summary
- track guess statistics in localStorage and expose helper functions
- add `/stats` page to review totals and per-model breakdown
- configure React Router and navigation with new dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: existing issues in src/SvgButton.tsx)*
- `npx eslint src/App.tsx src/Home.tsx src/StatsPage.tsx src/main.tsx src/stats.ts`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aaae892cbc83268068fb2038e2044f