### PR TITLE
feat: add image folders for model guessing

### DIFF
--- a/public/images/ChatGPT/.gitkeep
+++ b/public/images/ChatGPT/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep directory tracked

--- a/public/images/Emu/.gitkeep
+++ b/public/images/Emu/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep directory tracked

--- a/public/images/Gemini/.gitkeep
+++ b/public/images/Gemini/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep directory tracked

--- a/public/images/Grok/.gitkeep
+++ b/public/images/Grok/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep directory tracked

--- a/public/images/Midjourney/.gitkeep
+++ b/public/images/Midjourney/.gitkeep
@@ -1,0 +1,1 @@
+Placeholder to keep directory tracked


### PR DESCRIPTION
## Summary
- create `public/images` directory with model-specific subfolders
- add `.gitkeep` placeholders in each subfolder to track empty directories

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68aaadeb9c808326a21264d61f780822