### PR TITLE
feat: add millionaire-style question UI

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,11 +1,7 @@
-import logo from './assets/logo.png';
+import MillionaireUI from './MillionaireUI.tsx';
 
 function Home() {
-  return (
-    <div className="flex min-h-screen items-center justify-center">
-      <img src={logo} alt="Guess The Model logo" className="w-64" />
-    </div>
-  );
+  return <MillionaireUI />;
 }
 
 export default Home;

--- a/src/MillionaireUI.tsx
+++ b/src/MillionaireUI.tsx
@@ -1,0 +1,24 @@
+import logo from './assets/logo.png';
+import SvgButton from './SvgButton.tsx';
+
+function MillionaireUI() {
+  const answers = ['Humanity', 'Health', 'Honor', 'Household'];
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-b from-indigo-950 to-blue-900 p-4 text-white">
+      <img src={logo} alt="Millionaire logo" className="w-32" />
+      <SvgButton
+        label="In the UK, the abbreviation NHS stands for National what Service?"
+        width={700}
+        disabled
+        className="pointer-events-none"
+      />
+      <div className="grid grid-cols-2 gap-4">
+        {answers.map((answer) => (
+          <SvgButton key={answer} label={answer} width={340} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default MillionaireUI;


### PR DESCRIPTION
## Summary
- add MillionaireUI component rendering question and four answer buttons with SvgButton
- update Home to display the new quiz layout

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Strings must use singlequote and other existing lint errors in SvgButton.tsx)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aab29d28d0832691725c21ac6bcd64