### PR TITLE
feat: apply game show theme to home page

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -9,7 +9,7 @@ const compat = new FlatCompat({
 });
 
 export default tseslint.config([
-  { ignores: ['dist', 'eslint.config.js'] },
+  { ignores: ['dist', 'eslint.config.js', 'tailwind.config.js'] },
   ...compat.extends('airbnb'),
   ...compat.extends('plugin:react-hooks/recommended'),
   {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,8 +31,8 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen bg-[#242424] text-white">
-      <nav className="navbar bg-base-300">
+    <div className="min-h-screen millionaire-background text-white">
+      <nav className="navbar bg-transparent">
         <div className="navbar-start">
           <div className="dropdown">
             <button

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -10,18 +10,18 @@ function Home() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-      <h1 className="text-2xl mb-4">Choose a mode</h1>
+      <h1 className="mb-4 text-2xl">Choose a mode</h1>
       <button
         type="button"
         onClick={() => setMode('classic')}
-        className="rounded bg-blue-600 px-4 py-2"
+        className="millionaire-button"
       >
         Classic
       </button>
       <button
         type="button"
         onClick={() => setMode('quiz')}
-        className="rounded bg-green-600 px-4 py-2"
+        className="millionaire-button"
       >
         Quiz
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,28 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+@layer components {
+  /* Radial gradient background inspired by the show's color scheme */
+  .millionaire-background {
+    background: radial-gradient(
+      circle at center,
+      #1a237e 0%,
+      #0b1444 70%,
+      #000000 100%
+    );
+  }
+
+  /* Button style matching the game's blue and gold theme */
+  .millionaire-button {
+    @apply rounded-full px-8 py-3 text-white;
+    background: linear-gradient(to bottom, #0a2472, #020d3b);
+    border: 2px solid #38bdf8;
+    box-shadow: 0 0 10px #38bdf8;
+  }
+
+  .millionaire-button:hover {
+    border-color: #fbbf24;
+    box-shadow: 0 0 10px #fbbf24;
+  }
+}


### PR DESCRIPTION
## Summary
- add radial gradient background and themed buttons inspired by game show
- make navbar transparent and apply new background to app
- ignore Tailwind config in eslint

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abdad354308326845fd32a53848453