### PR TITLE
Display logo above mode selection

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import Game from './Game.tsx';
+import logo from './assets/logo.png';
 
 function Home() {
   const [mode, setMode] = useState<'classic' | 'quiz' | null>(null);
@@ -10,6 +11,7 @@ function Home() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+      <img src={logo} alt="Logo" className="mb-4 w-32" />
       <h1 className="mb-4 text-2xl">Choose a mode</h1>
       <button
         type="button"


### PR DESCRIPTION
## Summary
- Show logo above the mode selection on the home page

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abdfb159188326b139b67b6958c6c3