### PR TITLE
Adjust home and audio controls

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,15 +5,14 @@ import StatsPage from './StatsPage.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
 function App() {
-  const [musicOn, setMusicOn] = useState(true);
-  const [sfxOn, setSfxOn] = useState(true);
-
-  useEffect(() => {
-    playMusic('/audio/bgm/theme.wav');
-  }, []);
+  const [musicOn, setMusicOn] = useState(false);
+  const [sfxOn, setSfxOn] = useState(false);
 
   useEffect(() => {
     setMusicEnabled(musicOn);
+    if (musicOn) {
+      playMusic('/audio/bgm/theme.wav');
+    }
   }, [musicOn]);
 
   useEffect(() => {
@@ -55,20 +54,20 @@ function App() {
             >
               <li><Link to="/">Home</Link></li>
               <li><Link to="/stats">Stats</Link></li>
-              <li>
+              <li className="lg:hidden">
                 <button
                   type="button"
                   onClick={toggleMusic}
-                  className="millionaire-button"
+                  className="millionaire-button px-6 py-2 text-sm"
                 >
                   Music: {musicOn ? 'On' : 'Off'}
                 </button>
               </li>
-              <li>
+              <li className="lg:hidden">
                 <button
                   type="button"
                   onClick={toggleSfx}
-                  className="millionaire-button"
+                  className="millionaire-button px-6 py-2 text-sm"
                 >
                   SFX: {sfxOn ? 'On' : 'Off'}
                 </button>
@@ -76,23 +75,23 @@ function App() {
             </ul>
           </div>
         </div>
-        <div className="navbar-end hidden gap-2 lg:flex">
-          <button
-            type="button"
-            onClick={toggleMusic}
-            className="millionaire-button"
-          >
-            Music: {musicOn ? 'On' : 'Off'}
-          </button>
-          <button
-            type="button"
-            onClick={toggleSfx}
-            className="millionaire-button"
-          >
-            SFX: {sfxOn ? 'On' : 'Off'}
-          </button>
-        </div>
       </nav>
+      <div className="fixed bottom-4 right-4 hidden flex-col gap-2 lg:flex">
+        <button
+          type="button"
+          onClick={toggleMusic}
+          className="millionaire-button px-6 py-2 text-sm"
+        >
+          Music: {musicOn ? 'On' : 'Off'}
+        </button>
+        <button
+          type="button"
+          onClick={toggleSfx}
+          className="millionaire-button px-6 py-2 text-sm"
+        >
+          SFX: {sfxOn ? 'On' : 'Off'}
+        </button>
+      </div>
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/stats" element={<StatsPage />} />

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -11,22 +11,23 @@ function Home() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-      <img src={logo} alt="Logo" className="mb-4 w-32" />
-      <h1 className="mb-4 text-2xl">Choose a mode</h1>
-      <button
-        type="button"
-        onClick={() => setMode('classic')}
-        className="millionaire-button"
-      >
-        Classic
-      </button>
-      <button
-        type="button"
-        onClick={() => setMode('quiz')}
-        className="millionaire-button"
-      >
-        Quiz
-      </button>
+      <img src={logo} alt="Logo" className="mb-4 w-96" />
+      <div className="flex gap-4">
+        <button
+          type="button"
+          onClick={() => setMode('classic')}
+          className="millionaire-button"
+        >
+          Classic
+        </button>
+        <button
+          type="button"
+          onClick={() => setMode('quiz')}
+          className="millionaire-button"
+        >
+          Quiz
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -1,6 +1,6 @@
 let musicAudio: HTMLAudioElement | null = null;
-let musicEnabled = true;
-let sfxEnabled = true;
+let musicEnabled = false;
+let sfxEnabled = false;
 
 export function playMusic(src: string) {
   if (musicAudio) {


### PR DESCRIPTION
## Summary
- Enlarge home page logo and place mode buttons side-by-side
- Default audio off and relocate music/SFX controls to bottom-right on desktop
- Show audio toggles in burger menu on mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abe1d100bc8326b6cc579928126e71