### PR TITLE
Add routes for classic and quiz modes with home navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,12 +1,16 @@
-import { Link, Route, Routes } from 'react-router-dom';
+import {
+  Link, Route, Routes, useLocation,
+} from 'react-router-dom';
 import { useEffect, useState } from 'react';
 import Home from './Home.tsx';
 import StatsPage from './StatsPage.tsx';
+import Game from './Game.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
 function App() {
   const [musicOn, setMusicOn] = useState(true);
   const [sfxOn, setSfxOn] = useState(true);
+  const location = useLocation();
 
   useEffect(() => {
     playMusic('/audio/bgm/theme.wav');
@@ -76,6 +80,11 @@ function App() {
             </ul>
           </div>
         </div>
+        {['/classic', '/quiz'].includes(location.pathname) && (
+        <div className="navbar-center">
+          <Link to="/" className="millionaire-button">Home</Link>
+        </div>
+        )}
         <div className="navbar-end hidden gap-2 lg:flex">
           <button
             type="button"
@@ -96,6 +105,8 @@ function App() {
       <Routes>
         <Route path="/" element={<Home />} />
         <Route path="/stats" element={<StatsPage />} />
+        <Route path="/classic" element={<Game mode="classic" />} />
+        <Route path="/quiz" element={<Game mode="quiz" />} />
       </Routes>
     </div>
   );

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -6,7 +6,6 @@ import MoneyLadder from './MoneyLadder.tsx';
 
 type GameProps = {
   mode: 'classic' | 'quiz';
-  onReset: () => void;
 };
 
 function getRandomQuestion() {
@@ -15,12 +14,19 @@ function getRandomQuestion() {
   return entries[index];
 }
 
-function Game({ mode, onReset }: GameProps) {
+function Game({ mode }: GameProps) {
   const totalQuestions = mode === 'classic' ? moneyLadder.length : 20;
   const [currentQuestion, setCurrentQuestion] = useState(getRandomQuestion());
   const [questionIndex, setQuestionIndex] = useState(0);
   const [correct, setCorrect] = useState(0);
   const [finished, setFinished] = useState(false);
+
+  const resetGame = () => {
+    setCurrentQuestion(getRandomQuestion());
+    setQuestionIndex(0);
+    setCorrect(0);
+    setFinished(false);
+  };
 
   const handleAnswer = (answer: ModelName) => {
     const isCorrect = answer === currentQuestion.modelName;
@@ -64,7 +70,7 @@ function Game({ mode, onReset }: GameProps) {
       return (
         <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
           <p className="text-xl">{message}</p>
-          <button type="button" onClick={onReset} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
+          <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
         </div>
       );
     }
@@ -79,7 +85,7 @@ function Game({ mode, onReset }: GameProps) {
       <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
         <p className="text-xl">You scored {correct} out of {totalQuestions}</p>
         <p className="text-lg">Rank: {rank}</p>
-        <button type="button" onClick={onReset} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
+        <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
       </div>
     );
   }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,32 +1,17 @@
-import { useState } from 'react';
-import Game from './Game.tsx';
+import { Link } from 'react-router-dom';
 import logo from './assets/logo.png';
 
 function Home() {
-  const [mode, setMode] = useState<'classic' | 'quiz' | null>(null);
-
-  if (mode) {
-    return <Game mode={mode} onReset={() => setMode(null)} />;
-  }
-
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
       <img src={logo} alt="Logo" className="mb-4 w-32" />
       <h1 className="mb-4 text-2xl">Choose a mode</h1>
-      <button
-        type="button"
-        onClick={() => setMode('classic')}
-        className="millionaire-button"
-      >
+      <Link to="/classic" className="millionaire-button">
         Classic
-      </button>
-      <button
-        type="button"
-        onClick={() => setMode('quiz')}
-        className="millionaire-button"
-      >
+      </Link>
+      <Link to="/quiz" className="millionaire-button">
         Quiz
-      </button>
+      </Link>
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add `/classic` and `/quiz` routes that render the game with appropriate mode
- Show a top-level Home button when visiting classic or quiz
- Simplify Home component to link to routes and let Game reset internally

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abe24de95483269b5033ab04dd309c