### PR TITLE
feat: add purple menu and animated logo

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -36,7 +36,7 @@ function App() {
           <div className="dropdown">
             <button
               type="button"
-              className="btn btn-ghost"
+              className="btn btn-ghost bg-[#0b1444] text-white"
               aria-label="Open menu"
             >
               <svg
@@ -50,7 +50,7 @@ function App() {
               </svg>
             </button>
             <ul
-              className="menu menu-sm dropdown-content mt-3 w-52 rounded-box bg-base-300 p-2 shadow"
+              className="menu menu-sm dropdown-content mt-3 w-52 rounded-box bg-[#0b1444] p-2 shadow text-white"
             >
               <li><Link to="/">Home</Link></li>
               <li><Link to="/stats">Stats</Link></li>

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -11,7 +11,9 @@ function Home() {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-      <img src={logo} alt="Logo" className="mb-4 w-96" />
+      <div className="logo-animation mb-4 w-96">
+        <img src={logo} alt="Logo" className="w-full" />
+      </div>
       <div className="flex gap-4">
         <button
           type="button"

--- a/src/index.css
+++ b/src/index.css
@@ -25,4 +25,53 @@
     border-color: #fbbf24;
     box-shadow: 0 0 10px #fbbf24;
   }
+
+  .logo-animation {
+    @apply relative flex items-center justify-center;
+  }
+
+  .logo-animation::before {
+    content: '';
+    position: absolute;
+    width: 110%;
+    height: 110%;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(147, 51, 234, 0.6), transparent 70%);
+    animation: halo 2s ease-in-out infinite;
+    z-index: -1;
+  }
+
+  .logo-animation::after {
+    content: '';
+    position: absolute;
+    width: 130%;
+    height: 130%;
+    border-radius: 50%;
+    background: radial-gradient(circle, rgba(147, 51, 234, 0.3), transparent 70%);
+    animation: flame 1.5s ease-in-out infinite;
+    z-index: -2;
+    filter: blur(8px);
+  }
+}
+
+@keyframes halo {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 0.7;
+  }
+  50% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+}
+
+@keyframes flame {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 0.4;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 0.8;
+  }
 }


### PR DESCRIPTION
## Summary
- darken navbar burger menu and dropdown
- add purple flame halo animation around home logo

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abe33398788326a47ade1f4537aeb8