### PR TITLE
Prevent home page scroll from navigation and logo overflow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   };
 
   return (
-    <div className="flex min-h-screen flex-col millionaire-background text-white">
+    <div className="flex h-screen flex-col overflow-hidden millionaire-background text-white">
       <nav className="navbar bg-transparent">
         <div className="navbar-start">
           <div className="dropdown">
@@ -92,7 +92,7 @@ function App() {
           SFX: {sfxOn ? 'On' : 'Off'}
         </button>
       </div>
-      <main className="flex flex-1">
+      <main className="flex flex-1 overflow-auto">
         <Routes>
           <Route path="/" element={<Home />} />
           <Route path="/stats" element={<StatsPage />} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -30,7 +30,7 @@ function App() {
   };
 
   return (
-    <div className="min-h-screen millionaire-background text-white">
+    <div className="flex min-h-screen flex-col millionaire-background text-white">
       <nav className="navbar bg-transparent">
         <div className="navbar-start">
           <div className="dropdown">
@@ -92,10 +92,12 @@ function App() {
           SFX: {sfxOn ? 'On' : 'Off'}
         </button>
       </div>
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/stats" element={<StatsPage />} />
-      </Routes>
+      <main className="flex flex-1">
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/stats" element={<StatsPage />} />
+        </Routes>
+      </main>
     </div>
   );
 }

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -10,8 +10,8 @@ function Home() {
   }
 
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-      <img src={logo} alt="Logo" className="mb-4 w-96" />
+    <div className="flex flex-1 flex-col items-center justify-center gap-4 text-white">
+      <img src={logo} alt="Logo" className="mb-4 w-96 max-w-full" />
       <div className="flex gap-4">
         <button
           type="button"


### PR DESCRIPTION
## Summary
- restructure layout to use a flex column and main wrapper so navbar doesn't push content past viewport
- allow logo to shrink with screen size to avoid horizontal overflow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abe3a572748326a5308afe0b5049dc