### PR TITLE
Add classic and quiz routes with home navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,6 +6,7 @@ import {
 } from 'react';
 import Home from './Home.tsx';
 import StatsPage from './StatsPage.tsx';
+import Game from './Game.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
 function App() {
@@ -122,6 +123,8 @@ function App() {
       <main className="flex flex-1 overflow-auto">
         <Routes>
           <Route path="/" element={<Home />} />
+          <Route path="/classic" element={<Game mode="classic" />} />
+          <Route path="/quiz" element={<Game mode="quiz" />} />
           <Route path="/stats" element={<StatsPage />} />
         </Routes>
       </main>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Link } from 'react-router-dom';
 import SvgButton from './SvgButton.tsx';
 import { questions, ModelName } from './questions.ts';
 import moneyLadder from './moneyLadder.ts';
@@ -6,7 +7,6 @@ import MoneyLadder from './MoneyLadder.tsx';
 
 type GameProps = {
   mode: 'classic' | 'quiz';
-  onReset: () => void;
 };
 
 function getRandomQuestion() {
@@ -15,12 +15,19 @@ function getRandomQuestion() {
   return entries[index];
 }
 
-function Game({ mode, onReset }: GameProps) {
+function Game({ mode }: GameProps) {
   const totalQuestions = mode === 'classic' ? moneyLadder.length : 20;
   const [currentQuestion, setCurrentQuestion] = useState(getRandomQuestion());
   const [questionIndex, setQuestionIndex] = useState(0);
   const [correct, setCorrect] = useState(0);
   const [finished, setFinished] = useState(false);
+
+  const resetGame = () => {
+    setCurrentQuestion(getRandomQuestion());
+    setQuestionIndex(0);
+    setCorrect(0);
+    setFinished(false);
+  };
 
   const handleAnswer = (answer: ModelName) => {
     const isCorrect = answer === currentQuestion.modelName;
@@ -62,9 +69,10 @@ function Game({ mode, onReset }: GameProps) {
         ? 'Congratulations! You won a million!'
         : `Game over! You won $${prize}`;
       return (
-        <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+        <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+          <Link to="/" className="millionaire-button absolute left-4 top-4 px-4 py-2">Home</Link>
           <p className="text-xl">{message}</p>
-          <button type="button" onClick={onReset} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
+          <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
         </div>
       );
     }
@@ -76,10 +84,11 @@ function Game({ mode, onReset }: GameProps) {
       return 'Keep practicing!';
     })();
     return (
-      <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+      <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+        <Link to="/" className="millionaire-button absolute left-4 top-4 px-4 py-2">Home</Link>
         <p className="text-xl">You scored {correct} out of {totalQuestions}</p>
         <p className="text-lg">Rank: {rank}</p>
-        <button type="button" onClick={onReset} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
+        <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
       </div>
     );
   }
@@ -87,7 +96,8 @@ function Game({ mode, onReset }: GameProps) {
   const options = Object.values(ModelName);
 
   return (
-    <div className="flex min-h-screen items-center justify-center p-4 text-white">
+    <div className="relative flex min-h-screen items-center justify-center p-4 text-white">
+      <Link to="/" className="millionaire-button absolute left-4 top-4 px-4 py-2">Home</Link>
       <div className="flex w-full max-w-5xl items-start gap-6">
         <div className="flex flex-1 flex-col items-center gap-4">
           <p className="text-lg">

--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -1,34 +1,19 @@
-import { useState } from 'react';
-import Game from './Game.tsx';
+import { Link } from 'react-router-dom';
 import logo from './assets/logo.png';
 
 function Home() {
-  const [mode, setMode] = useState<'classic' | 'quiz' | null>(null);
-
-  if (mode) {
-    return <Game mode={mode} onReset={() => setMode(null)} />;
-  }
-
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
       <div className="logo-animation mb-4 w-96">
         <img src={logo} alt="Logo" className="w-full" />
       </div>
       <div className="flex gap-4">
-        <button
-          type="button"
-          onClick={() => setMode('classic')}
-          className="millionaire-button"
-        >
+        <Link to="/classic" className="millionaire-button">
           Classic
-        </button>
-        <button
-          type="button"
-          onClick={() => setMode('quiz')}
-          className="millionaire-button"
-        >
+        </Link>
+        <Link to="/quiz" className="millionaire-button">
           Quiz
-        </button>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add dedicated `/classic` and `/quiz` routes
- replace in-component mode handling with links to classic and quiz
- show persistent Home button during gameplay

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abe60f8b408326a99e03fe1062c817