### PR TITLE
Center home content and add purple flame logo animation

### DIFF
--- a/src/Home.tsx
+++ b/src/Home.tsx
@@ -3,11 +3,11 @@ import logo from './assets/logo.png';
 
 function Home() {
   return (
-    <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+    <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-center text-white">
       <div className="logo-animation mb-4 w-96">
         <img src={logo} alt="Logo" className="w-full" />
       </div>
-      <div className="flex gap-4">
+      <div className="flex justify-center gap-4">
         <Link to="/classic" className="millionaire-button">
           Classic
         </Link>

--- a/src/index.css
+++ b/src/index.css
@@ -43,45 +43,50 @@
   .logo-animation::before {
     content: '';
     position: absolute;
-    width: 110%;
-    height: 110%;
+    width: 120%;
+    height: 120%;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(147, 51, 234, 0.6), transparent 70%);
-    animation: halo 2s ease-in-out infinite;
+    background: radial-gradient(circle, rgba(76, 29, 149, 0.6), transparent 70%);
+    filter: blur(10px);
+    animation: halo 3s ease-in-out infinite;
     z-index: -1;
   }
 
   .logo-animation::after {
     content: '';
     position: absolute;
-    width: 130%;
-    height: 130%;
+    width: 150%;
+    height: 150%;
     border-radius: 50%;
-    background: radial-gradient(circle, rgba(147, 51, 234, 0.3), transparent 70%);
-    animation: flame 1.5s ease-in-out infinite;
+    background: radial-gradient(circle, rgba(76, 29, 149, 0.4), transparent 70%);
+    filter: blur(25px);
+    animation: flame 2s ease-in-out infinite;
     z-index: -2;
-    filter: blur(8px);
   }
 }
 
 @keyframes halo {
   0%, 100% {
     transform: scale(1);
-    opacity: 0.7;
+    opacity: 0.6;
   }
   50% {
     transform: scale(1.1);
-    opacity: 1;
+    opacity: 0.9;
   }
 }
 
 @keyframes flame {
-  0%, 100% {
-    transform: scale(1);
-    opacity: 0.4;
+  0% {
+    transform: scale(1) rotate(-3deg);
+    opacity: 0.5;
   }
   50% {
-    transform: scale(1.2);
-    opacity: 0.8;
+    transform: scale(1.2) rotate(3deg);
+    opacity: 0.9;
+  }
+  100% {
+    transform: scale(1) rotate(-3deg);
+    opacity: 0.5;
   }
 }


### PR DESCRIPTION
## Summary
- center logo and classic/quiz links on home page
- add dark purple flame-like glow animation around logo

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abe794696483268b8e2269d1738bd8