### PR TITLE
Place Home button before burger menu on game screens

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,9 @@
-import { Link, Route, Routes } from 'react-router-dom';
+import {
+  Link,
+  Route,
+  Routes,
+  useLocation,
+} from 'react-router-dom';
 import {
   useEffect,
   useRef,
@@ -15,6 +20,8 @@ function App() {
   const [menuOpen, setMenuOpen] = useState(false);
   const menuRef = useRef<HTMLDivElement>(null);
   const menuButtonRef = useRef<HTMLButtonElement>(null);
+  const location = useLocation();
+  const showHomeButton = location.pathname === '/classic' || location.pathname === '/quiz';
 
   useEffect(() => {
     setMusicEnabled(musicOn);
@@ -62,7 +69,10 @@ function App() {
   return (
     <div className="flex h-screen flex-col overflow-hidden millionaire-background text-white">
       <nav className="navbar bg-transparent">
-        <div className="navbar-start">
+        <div className="navbar-start flex items-center gap-2">
+          {showHomeButton && (
+            <Link to="/" className="millionaire-button px-4 py-2">Home</Link>
+          )}
           <div
             ref={menuRef}
             className={`dropdown ${menuOpen ? 'dropdown-open' : ''}`}

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -1,5 +1,4 @@
 import { useState } from 'react';
-import { Link } from 'react-router-dom';
 import SvgButton from './SvgButton.tsx';
 import { questions, ModelName } from './questions.ts';
 import moneyLadder from './moneyLadder.ts';
@@ -70,7 +69,6 @@ function Game({ mode }: GameProps) {
         : `Game over! You won $${prize}`;
       return (
         <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-          <Link to="/" className="millionaire-button absolute left-4 top-4 px-4 py-2">Home</Link>
           <p className="text-xl">{message}</p>
           <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
         </div>
@@ -85,7 +83,6 @@ function Game({ mode }: GameProps) {
     })();
     return (
       <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-        <Link to="/" className="millionaire-button absolute left-4 top-4 px-4 py-2">Home</Link>
         <p className="text-xl">You scored {correct} out of {totalQuestions}</p>
         <p className="text-lg">Rank: {rank}</p>
         <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
@@ -97,7 +94,6 @@ function Game({ mode }: GameProps) {
 
   return (
     <div className="relative flex min-h-screen items-center justify-center p-4 text-white">
-      <Link to="/" className="millionaire-button absolute left-4 top-4 px-4 py-2">Home</Link>
       <div className="flex w-full max-w-5xl items-start gap-6">
         <div className="flex flex-1 flex-col items-center gap-4">
           <p className="text-lg">


### PR DESCRIPTION
## Summary
- Show a Home button in the navbar when viewing classic or quiz modes
- Remove redundant in-page Home links from the Game component

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68abea69e42c8326b3717631e05cef50