### PR TITLE
refactor: organize routes and components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,13 +3,14 @@ import {
   useEffect,
   useRef,
   useState,
+  type ReactElement,
 } from 'react';
-import Home from './Home.tsx';
-import StatsPage from './StatsPage.tsx';
-import Game from './Game.tsx';
+import Home from './routes/Home.tsx';
+import StatsPage from './routes/StatsPage.tsx';
+import Game from './routes/Game.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
-function App() {
+function App(): ReactElement {
   const [musicOn, setMusicOn] = useState(false);
   const [sfxOn, setSfxOn] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -27,17 +28,17 @@ function App() {
     setSfxEnabled(sfxOn);
   }, [sfxOn]);
 
-  const toggleMusic = () => {
+  const toggleMusic = (): void => {
     setMusicOn((prev) => !prev);
     playSound('/audio/sfx/click.wav');
   };
 
-  const toggleSfx = () => {
+  const toggleSfx = (): void => {
     playSound('/audio/sfx/click.wav');
     setSfxOn((prev) => !prev);
   };
 
-  const toggleMenu = () => {
+  const toggleMenu = (): void => {
     playSound('/audio/sfx/click.wav');
     setMenuOpen((prev) => {
       if (prev) {
@@ -48,7 +49,7 @@ function App() {
   };
 
   useEffect(() => {
-    const handleClickOutside = (event: MouseEvent) => {
+    const handleClickOutside = (event: MouseEvent): void => {
       if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
         setMenuOpen(false);
       }

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -2,7 +2,7 @@ let musicAudio: HTMLAudioElement | null = null;
 let musicEnabled = false;
 let sfxEnabled = false;
 
-export function playMusic(src: string) {
+export function playMusic(src: string): void {
   if (musicAudio) {
     musicAudio.pause();
   }
@@ -15,7 +15,7 @@ export function playMusic(src: string) {
   }
 }
 
-export function setMusicEnabled(enabled: boolean) {
+export function setMusicEnabled(enabled: boolean): void {
   musicEnabled = enabled;
   if (musicAudio) {
     if (enabled) {
@@ -28,7 +28,7 @@ export function setMusicEnabled(enabled: boolean) {
   }
 }
 
-export function setSfxEnabled(enabled: boolean) {
+export function setSfxEnabled(enabled: boolean): void {
   sfxEnabled = enabled;
 }
 
@@ -37,7 +37,7 @@ export function setSfxEnabled(enabled: boolean) {
  * The source should reference a file located in the public/audio directory,
  * for example '/audio/sfx/click.wav'.
  */
-export default function playSound(src: string) {
+export default function playSound(src: string): void {
   if (!sfxEnabled) return;
   const audio = new Audio(src);
   audio.play().catch(() => {

--- a/src/components/MillionaireUI.tsx
+++ b/src/components/MillionaireUI.tsx
@@ -1,6 +1,7 @@
-import questionImage from './assets/question.png';
+import { type ReactElement } from 'react';
+import questionImage from '../assets/question.png';
 
-function MillionaireUI() {
+function MillionaireUI(): ReactElement {
   const answers = ['Humanity', 'Health', 'Honor', 'Household'];
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-b from-indigo-950 to-blue-900 p-4 text-white">

--- a/src/components/MoneyLadder.tsx
+++ b/src/components/MoneyLadder.tsx
@@ -1,10 +1,11 @@
-import moneyLadder from './moneyLadder.ts';
+import type { ReactElement } from 'react';
+import moneyLadder from '../moneyLadder.ts';
 
 type MoneyLadderProps = {
   current: number; // zero-based index of current question
 };
 
-function MoneyLadder({ current }: MoneyLadderProps) {
+function MoneyLadder({ current }: MoneyLadderProps): ReactElement {
   const ladderDesc = [...moneyLadder].reverse();
 
   return (

--- a/src/components/SvgButton.tsx
+++ b/src/components/SvgButton.tsx
@@ -1,6 +1,6 @@
 /* eslint react/require-default-props: 0 */
-import { useEffect, useState } from 'react';
-import svgbutton from './assets/svgbutton.svg'; // <- tight-fit SVG file
+import { useEffect, useState, type ReactElement } from 'react';
+import svgbutton from '../assets/svgbutton.svg'; // <- tight-fit SVG file
 
 type SvgButtonProps = {
   onClick?: () => void;
@@ -18,12 +18,12 @@ function SvgButton({
   className = '',
   disabled = false,
   title = undefined,
-}: SvgButtonProps) {
+}: SvgButtonProps): ReactElement {
   const [isSelected, setIsSelected] = useState(false);
   const [blinkColor, setBlinkColor] = useState<string | null>(null);
   const [currentColor, setCurrentColor] = useState<string>('transparent');
 
-  const handleClick = () => {
+  const handleClick = (): void => {
     if (isSelected) return;
     setIsSelected(true);
     setCurrentColor('orange');
@@ -33,7 +33,7 @@ function SvgButton({
 
   useEffect(() => {
     if (!isSelected || !blinkColor) return undefined;
-    const interval = setInterval(() => {
+    const interval: ReturnType<typeof setInterval> = setInterval(() => {
       setCurrentColor((prev) => (prev === 'orange' ? blinkColor : 'orange'));
     }, 500);
     return () => clearInterval(interval);

--- a/src/routes/Game.tsx
+++ b/src/routes/Game.tsx
@@ -1,35 +1,35 @@
-import { useState } from 'react';
+import { useState, type ReactElement } from 'react';
 import { Link } from 'react-router-dom';
-import SvgButton from './SvgButton.tsx';
-import { questions, ModelName } from './questions.ts';
-import moneyLadder from './moneyLadder.ts';
-import MoneyLadder from './MoneyLadder.tsx';
+import SvgButton from '../components/SvgButton.tsx';
+import MoneyLadder from '../components/MoneyLadder.tsx';
+import moneyLadder from '../moneyLadder.ts';
+import { questions, ModelName, type QuestionEntry } from '../questions.ts';
 
 type GameProps = {
   mode: 'classic' | 'quiz';
 };
 
-function getRandomQuestion() {
+function getRandomQuestion(): QuestionEntry {
   const entries = Object.values(questions);
   const index = Math.floor(Math.random() * entries.length);
   return entries[index];
 }
 
-function Game({ mode }: GameProps) {
+function Game({ mode }: GameProps): ReactElement {
   const totalQuestions = mode === 'classic' ? moneyLadder.length : 20;
   const [currentQuestion, setCurrentQuestion] = useState(getRandomQuestion());
   const [questionIndex, setQuestionIndex] = useState(0);
   const [correct, setCorrect] = useState(0);
   const [finished, setFinished] = useState(false);
 
-  const resetGame = () => {
+  const resetGame = (): void => {
     setCurrentQuestion(getRandomQuestion());
     setQuestionIndex(0);
     setCorrect(0);
     setFinished(false);
   };
 
-  const handleAnswer = (answer: ModelName) => {
+  const handleAnswer = (answer: ModelName): void => {
     const isCorrect = answer === currentQuestion.modelName;
     if (isCorrect) {
       setCorrect((prev) => prev + 1);
@@ -93,7 +93,7 @@ function Game({ mode }: GameProps) {
     );
   }
 
-  const options = Object.values(ModelName);
+  const options: ModelName[] = Object.values(ModelName);
 
   return (
     <div className="relative flex min-h-screen items-center justify-center p-4 text-white">

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
-import logo from './assets/logo.png';
+import { type ReactElement } from 'react';
+import logo from '../assets/logo.png';
 
-function Home() {
+function Home(): ReactElement {
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-4 text-center text-white">
       <div className="logo-animation mb-4 w-96">

--- a/src/routes/StatsPage.tsx
+++ b/src/routes/StatsPage.tsx
@@ -1,12 +1,12 @@
-import { useEffect, useState } from 'react';
-import { getStats, clearStats } from './stats.ts';
-import type { Stats } from './stats.ts';
+import { useEffect, useState, type ReactElement } from 'react';
+import { getStats, clearStats } from '../stats.ts';
+import type { Stats } from '../stats.ts';
 
-function StatsPage() {
+function StatsPage(): ReactElement {
   const [stats, setStats] = useState<Stats>(getStats());
 
   useEffect(() => {
-    const update = () => setStats(getStats());
+    const update = (): void => setStats(getStats());
     window.addEventListener('storage', update);
     return () => window.removeEventListener('storage', update);
   }, []);


### PR DESCRIPTION
## Summary
- Move pages into `routes/` and UI pieces into `components/` with updated imports
- Add explicit ReactElement and void return types to components and audio helpers
- Minor path fixes for assets after restructuring

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abeab6b358832695e1d214dbbaf14b