### PR TITLE
Refactor routes/components and align nav layout

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,13 +8,14 @@ import {
   useEffect,
   useRef,
   useState,
+  type ReactElement,
 } from 'react';
-import Home from './Home.tsx';
-import StatsPage from './StatsPage.tsx';
-import Game from './Game.tsx';
+import Home from './routes/Home.tsx';
+import StatsPage from './routes/StatsPage.tsx';
+import Game from './routes/Game.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
-function App() {
+function App(): ReactElement {
   const [musicOn, setMusicOn] = useState(false);
   const [sfxOn, setSfxOn] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
@@ -70,16 +71,13 @@ function App() {
     <div className="flex h-screen flex-col overflow-hidden millionaire-background text-white">
       <nav className="navbar bg-transparent">
         <div className="navbar-start flex items-center gap-2">
-          {showHomeButton && (
-            <Link to="/" className="millionaire-button px-4 py-2">Home</Link>
-          )}
           <div
             ref={menuRef}
             className={`dropdown ${menuOpen ? 'dropdown-open' : ''}`}
           >
             <button
               type="button"
-              className="btn btn-ghost bg-[#0b1444] text-white"
+              className="millionaire-button flex items-center justify-center px-4 py-2"
               aria-label="Open menu"
               onClick={toggleMenu}
               ref={menuButtonRef}
@@ -119,6 +117,9 @@ function App() {
               </li>
             </ul>
           </div>
+          {showHomeButton && (
+            <Link to="/" className="millionaire-button px-4 py-2">Home</Link>
+          )}
         </div>
       </nav>
       <div className="fixed bottom-4 right-4 hidden flex-col gap-2 lg:flex">

--- a/src/audio.ts
+++ b/src/audio.ts
@@ -2,7 +2,7 @@ let musicAudio: HTMLAudioElement | null = null;
 let musicEnabled = false;
 let sfxEnabled = false;
 
-export function playMusic(src: string) {
+export function playMusic(src: string): void {
   if (musicAudio) {
     musicAudio.pause();
   }
@@ -15,7 +15,7 @@ export function playMusic(src: string) {
   }
 }
 
-export function setMusicEnabled(enabled: boolean) {
+export function setMusicEnabled(enabled: boolean): void {
   musicEnabled = enabled;
   if (musicAudio) {
     if (enabled) {
@@ -28,7 +28,7 @@ export function setMusicEnabled(enabled: boolean) {
   }
 }
 
-export function setSfxEnabled(enabled: boolean) {
+export function setSfxEnabled(enabled: boolean): void {
   sfxEnabled = enabled;
 }
 
@@ -37,7 +37,7 @@ export function setSfxEnabled(enabled: boolean) {
  * The source should reference a file located in the public/audio directory,
  * for example '/audio/sfx/click.wav'.
  */
-export default function playSound(src: string) {
+export default function playSound(src: string): void {
   if (!sfxEnabled) return;
   const audio = new Audio(src);
   audio.play().catch(() => {

--- a/src/components/MillionaireUI.tsx
+++ b/src/components/MillionaireUI.tsx
@@ -1,7 +1,8 @@
-import questionImage from './assets/question.png';
+import type { ReactElement } from 'react';
+import questionImage from '../assets/question.png';
 
-function MillionaireUI() {
-  const answers = ['Humanity', 'Health', 'Honor', 'Household'];
+function MillionaireUI(): ReactElement {
+  const answers: string[] = ['Humanity', 'Health', 'Honor', 'Household'];
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-8 bg-gradient-to-b from-indigo-950 to-blue-900 p-4 text-white">
       <img

--- a/src/components/MoneyLadder.tsx
+++ b/src/components/MoneyLadder.tsx
@@ -1,10 +1,11 @@
-import moneyLadder from './moneyLadder.ts';
+import type { ReactElement } from 'react';
+import moneyLadder from '../moneyLadder.ts';
 
 type MoneyLadderProps = {
   current: number; // zero-based index of current question
 };
 
-function MoneyLadder({ current }: MoneyLadderProps) {
+function MoneyLadder({ current }: MoneyLadderProps): ReactElement {
   const ladderDesc = [...moneyLadder].reverse();
 
   return (

--- a/src/components/SvgButton.tsx
+++ b/src/components/SvgButton.tsx
@@ -1,6 +1,6 @@
 /* eslint react/require-default-props: 0 */
-import { useEffect, useState } from 'react';
-import svgbutton from './assets/svgbutton.svg'; // <- tight-fit SVG file
+import { useEffect, useState, type ReactElement } from 'react';
+import svgbutton from '../assets/svgbutton.svg'; // <- tight-fit SVG file
 
 type SvgButtonProps = {
   onClick?: () => void;
@@ -18,7 +18,7 @@ function SvgButton({
   className = '',
   disabled = false,
   title = undefined,
-}: SvgButtonProps) {
+}: SvgButtonProps): ReactElement {
   const [isSelected, setIsSelected] = useState(false);
   const [blinkColor, setBlinkColor] = useState<string | null>(null);
   const [currentColor, setCurrentColor] = useState<string>('transparent');

--- a/src/routes/Game.tsx
+++ b/src/routes/Game.tsx
@@ -1,20 +1,20 @@
-import { useState } from 'react';
-import SvgButton from './SvgButton.tsx';
-import { questions, ModelName } from './questions.ts';
-import moneyLadder from './moneyLadder.ts';
-import MoneyLadder from './MoneyLadder.tsx';
+import { useState, type ReactElement } from 'react';
+import SvgButton from '../components/SvgButton.tsx';
+import { questions, ModelName, type QuestionEntry } from '../questions.ts';
+import moneyLadder from '../moneyLadder.ts';
+import MoneyLadder from '../components/MoneyLadder.tsx';
 
 type GameProps = {
   mode: 'classic' | 'quiz';
 };
 
-function getRandomQuestion() {
+function getRandomQuestion(): QuestionEntry {
   const entries = Object.values(questions);
   const index = Math.floor(Math.random() * entries.length);
   return entries[index];
 }
 
-function Game({ mode }: GameProps) {
+function Game({ mode }: GameProps): ReactElement {
   const totalQuestions = mode === 'classic' ? moneyLadder.length : 20;
   const [currentQuestion, setCurrentQuestion] = useState(getRandomQuestion());
   const [questionIndex, setQuestionIndex] = useState(0);

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,7 +1,8 @@
 import { Link } from 'react-router-dom';
-import logo from './assets/logo.png';
+import type { ReactElement } from 'react';
+import logo from '../assets/logo.png';
 
-function Home() {
+function Home(): ReactElement {
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center text-white">
       <div className="logo-animation mb-4 w-96">

--- a/src/routes/StatsPage.tsx
+++ b/src/routes/StatsPage.tsx
@@ -1,8 +1,8 @@
-import { useEffect, useState } from 'react';
-import { getStats, clearStats } from './stats.ts';
-import type { Stats } from './stats.ts';
+import { useEffect, useState, type ReactElement } from 'react';
+import { getStats, clearStats } from '../stats.ts';
+import type { Stats } from '../stats.ts';
 
-function StatsPage() {
+function StatsPage(): ReactElement {
   const [stats, setStats] = useState<Stats>(getStats());
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- organize project by separating route pages and reusable components
- position Home link to right of burger menu and style both consistently
- add explicit TypeScript types across components and audio utilities

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68abebeaed4c8326b6cfec09460b8134