### PR TITLE
Add final screens with confetti for quiz and classic modes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "daisyui": "^5.0.50",
         "react": "^19.1.1",
+        "react-confetti": "^6.4.0",
         "react-dom": "^19.1.1",
         "react-router-dom": "^6.30.1"
       },
@@ -5704,6 +5705,21 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-confetti": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/react-confetti/-/react-confetti-6.4.0.tgz",
+      "integrity": "sha512-5MdGUcqxrTU26I2EU7ltkWPwxvucQTuqMm8dUz72z2YMqTD6s9vMcDUysk7n9jnC+lXuCPeJJ7Knf98VEYE9Rg==",
+      "license": "MIT",
+      "dependencies": {
+        "tween-functions": "^1.2.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "react": "^16.3.0 || ^17.0.1 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "19.1.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.1.tgz",
@@ -6724,6 +6740,12 @@
       "dev": true,
       "license": "0BSD",
       "optional": true
+    },
+    "node_modules/tween-functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tween-functions/-/tween-functions-1.2.0.tgz",
+      "integrity": "sha512-PZBtLYcCLtEcjL14Fzb1gSxPBeL7nWvGhO5ZFPGqziCcr8uvHp0NDmdjBchp6KHL+tExcg0m3NISmKxhU394dA==",
+      "license": "BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "daisyui": "^5.0.50",
     "react": "^19.1.1",
+    "react-confetti": "^6.4.0",
     "react-dom": "^19.1.1",
     "react-router-dom": "^6.30.1"
   },

--- a/src/components/ClassicFinalScreen.tsx
+++ b/src/components/ClassicFinalScreen.tsx
@@ -1,0 +1,35 @@
+import type { ReactElement } from 'react';
+import moneyLadder from '../moneyLadder.ts';
+import FinalScreen from './FinalScreen.tsx';
+
+type ClassicFinalScreenProps = {
+  correct: number;
+  onRestart: () => void;
+};
+
+function ClassicFinalScreen({ correct, onRestart }: ClassicFinalScreenProps): ReactElement {
+  let prize = 0;
+  if (correct === moneyLadder.length) {
+    prize = moneyLadder[moneyLadder.length - 1];
+  } else if (correct > 0) {
+    prize = moneyLadder[correct - 1];
+  }
+  const message = correct === moneyLadder.length
+    ? 'Congratulations! You won a million!'
+    : `Game over! You won $${prize}`;
+
+  return (
+    <FinalScreen>
+      <p className="text-xl">{message}</p>
+      <button
+        type="button"
+        onClick={onRestart}
+        className="rounded bg-blue-600 px-4 py-2"
+      >
+        Play Again
+      </button>
+    </FinalScreen>
+  );
+}
+
+export default ClassicFinalScreen;

--- a/src/components/FinalScreen.tsx
+++ b/src/components/FinalScreen.tsx
@@ -1,0 +1,41 @@
+import {
+  useEffect,
+  useState,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
+import Confetti from 'react-confetti';
+
+function useWindowSize() {
+  const [size, setSize] = useState({ width: window.innerWidth, height: window.innerHeight });
+  useEffect(() => {
+    const handleResize = () => {
+      setSize({ width: window.innerWidth, height: window.innerHeight });
+    };
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+  return size;
+}
+
+type FinalScreenProps = {
+  children: ReactNode;
+};
+
+function FinalScreen({ children }: FinalScreenProps): ReactElement {
+  const { width, height } = useWindowSize();
+
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
+      <Confetti
+        width={width}
+        height={height}
+        recycle={false}
+        className="pointer-events-none"
+      />
+      {children}
+    </div>
+  );
+}
+
+export default FinalScreen;

--- a/src/components/QuizFinalScreen.tsx
+++ b/src/components/QuizFinalScreen.tsx
@@ -1,0 +1,36 @@
+import type { ReactElement } from 'react';
+import FinalScreen from './FinalScreen.tsx';
+
+type QuizFinalScreenProps = {
+  correct: number;
+  total: number;
+  onRestart: () => void;
+};
+
+function QuizFinalScreen({ correct, total, onRestart }: QuizFinalScreenProps): ReactElement {
+  const rank = (() => {
+    if (correct === 20) return 'eagle eye';
+    if (correct >= 15) return 'AI connoisseur';
+    if (correct >= 10) return 'Ah, I have heard about that aye thing!';
+    if (correct < 5) return 'I swear this looks real!';
+    return 'Keep practicing!';
+  })();
+
+  return (
+    <FinalScreen>
+      <p className="text-xl">
+        You scored {correct} out of {total}
+      </p>
+      <p className="text-lg">Rank: {rank}</p>
+      <button
+        type="button"
+        onClick={onRestart}
+        className="rounded bg-blue-600 px-4 py-2"
+      >
+        Play Again
+      </button>
+    </FinalScreen>
+  );
+}
+
+export default QuizFinalScreen;

--- a/src/routes/Game.tsx
+++ b/src/routes/Game.tsx
@@ -2,6 +2,8 @@ import { useState, type ReactElement } from 'react';
 import { questions, ModelName, type QuestionEntry } from '../questions.ts';
 import moneyLadder from '../moneyLadder.ts';
 import MoneyLadder from '../components/MoneyLadder.tsx';
+import ClassicFinalScreen from '../components/ClassicFinalScreen.tsx';
+import QuizFinalScreen from '../components/QuizFinalScreen.tsx';
 
 type GameProps = {
   mode: 'classic' | 'quiz';
@@ -69,35 +71,16 @@ function Game({ mode }: GameProps): ReactElement {
 
   if (finished) {
     if (mode === 'classic') {
-      let prize = 0;
-      if (correct === moneyLadder.length) {
-        prize = moneyLadder[moneyLadder.length - 1];
-      } else if (correct > 0) {
-        prize = moneyLadder[correct - 1];
-      }
-      const message = correct === moneyLadder.length
-        ? 'Congratulations! You won a million!'
-        : `Game over! You won $${prize}`;
       return (
-        <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-          <p className="text-xl">{message}</p>
-          <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
-        </div>
+        <ClassicFinalScreen correct={correct} onRestart={resetGame} />
       );
     }
-    const rank = (() => {
-      if (correct === 20) return 'eagle eye';
-      if (correct >= 15) return 'AI connoisseur';
-      if (correct >= 10) return 'Ah, I have heard about that aye thing!';
-      if (correct < 5) return 'I swear this looks real!';
-      return 'Keep practicing!';
-    })();
     return (
-      <div className="relative flex min-h-screen flex-col items-center justify-center gap-4 text-white">
-        <p className="text-xl">You scored {correct} out of {totalQuestions}</p>
-        <p className="text-lg">Rank: {rank}</p>
-        <button type="button" onClick={resetGame} className="rounded bg-blue-600 px-4 py-2">Play Again</button>
-      </div>
+      <QuizFinalScreen
+        correct={correct}
+        total={totalQuestions}
+        onRestart={resetGame}
+      />
     );
   }
 


### PR DESCRIPTION
## Summary
- add `react-confetti` dependency
- introduce reusable `FinalScreen` component with confetti animation
- show dedicated final screens for classic and quiz modes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68ad4cba9c088326b85185e9fed80610