### PR TITLE
Track detailed guess statistics

### DIFF
--- a/src/routes/Game.tsx
+++ b/src/routes/Game.tsx
@@ -2,6 +2,7 @@ import { useState, type ReactElement } from 'react';
 import { questions, ModelName, type QuestionEntry } from '../questions.ts';
 import moneyLadder from '../moneyLadder.ts';
 import MoneyLadder from '../components/MoneyLadder.tsx';
+import { recordGuess } from '../stats.ts';
 
 type GameProps = {
   mode: 'classic' | 'quiz';
@@ -41,6 +42,7 @@ function Game({ mode }: GameProps): ReactElement {
 
   const handleAnswer = (answer: ModelName) => {
     const isCorrect = answer === currentQuestion.modelName;
+    recordGuess(currentQuestion.modelName, isCorrect, mode);
     if (isCorrect) {
       setCorrect((prev) => prev + 1);
     }

--- a/src/routes/StatsPage.tsx
+++ b/src/routes/StatsPage.tsx
@@ -19,6 +19,18 @@ function StatsPage(): ReactElement {
         <p>Correct: {stats.correct}</p>
         <p>Incorrect: {stats.incorrect}</p>
       </div>
+      <div className="mb-4">
+        <h2 className="mb-2 text-xl">Classic Mode</h2>
+        <p>Total guesses: {stats.classic.total}</p>
+        <p>Correct: {stats.classic.correct}</p>
+        <p>Incorrect: {stats.classic.incorrect}</p>
+      </div>
+      <div className="mb-4">
+        <h2 className="mb-2 text-xl">Quiz Mode</h2>
+        <p>Total guesses: {stats.quiz.total}</p>
+        <p>Correct: {stats.quiz.correct}</p>
+        <p>Incorrect: {stats.quiz.incorrect}</p>
+      </div>
       <h2 className="mb-2 text-xl">By Model</h2>
       <ul className="mb-4">
         {Object.entries(stats.models).map(([model, s]) => (

--- a/src/stats.ts
+++ b/src/stats.ts
@@ -4,10 +4,18 @@ export interface ModelStats {
   total: number;
 }
 
+export interface ModeStats {
+  correct: number;
+  incorrect: number;
+  total: number;
+}
+
 export interface Stats {
   correct: number;
   incorrect: number;
   total: number;
+  classic: ModeStats;
+  quiz: ModeStats;
   models: Record<string, ModelStats>;
 }
 
@@ -18,6 +26,8 @@ function getInitialStats(): Stats {
     correct: 0,
     incorrect: 0,
     total: 0,
+    classic: { correct: 0, incorrect: 0, total: 0 },
+    quiz: { correct: 0, incorrect: 0, total: 0 },
     models: {},
   };
 }
@@ -26,13 +36,21 @@ export function getStats(): Stats {
   const raw = localStorage.getItem(STORAGE_KEY);
   if (!raw) return getInitialStats();
   try {
-    return JSON.parse(raw) as Stats;
+    const parsed = JSON.parse(raw) as Partial<Stats>;
+    const initial = getInitialStats();
+    return {
+      ...initial,
+      ...parsed,
+      classic: { ...initial.classic, ...parsed?.classic },
+      quiz: { ...initial.quiz, ...parsed?.quiz },
+      models: parsed?.models ?? {},
+    };
   } catch {
     return getInitialStats();
   }
 }
 
-export function recordGuess(model: string, isCorrect: boolean): void {
+export function recordGuess(model: string, isCorrect: boolean, mode: 'classic' | 'quiz'): void {
   const stats = getStats();
   if (!stats.models[model]) {
     stats.models[model] = { correct: 0, incorrect: 0, total: 0 };
@@ -40,12 +58,15 @@ export function recordGuess(model: string, isCorrect: boolean): void {
   const modelStats = stats.models[model];
   if (isCorrect) {
     stats.correct += 1;
+    stats[mode].correct += 1;
     modelStats.correct += 1;
   } else {
     stats.incorrect += 1;
+    stats[mode].incorrect += 1;
     modelStats.incorrect += 1;
   }
   stats.total += 1;
+  stats[mode].total += 1;
   modelStats.total += 1;
   localStorage.setItem(STORAGE_KEY, JSON.stringify(stats));
 }


### PR DESCRIPTION
## Summary
- track overall, classic mode, and quiz mode guess counts
- record guesses each time a player answers
- display mode-specific stats in the statistics page

## Testing
- `npm test` (fails: Missing script: test)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ad4d3bb0048326a07bc0e7d4dc33ab