### PR TITLE
fix: ensure logo flame animation displays

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -38,6 +38,11 @@
 
   .logo-animation {
     @apply relative flex items-center justify-center;
+    z-index: 0;
+  }
+
+  .logo-animation img {
+    @apply relative z-10;
   }
 
   .logo-animation::before {


### PR DESCRIPTION
## Summary
- fix flame animation z-index by establishing stacking context and layering

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Unable to resolve module 'cypress'; Unable to resolve module 'react-confetti'; More than 1 blank line not allowed; Parameter declaration expected)*
- `npm run build` *(fails: stats.ts(54,63): error TS1138: Parameter declaration expected)*

------
https://chatgpt.com/codex/tasks/task_e_68ad503152b08326b41e2d5e07f672fc