### PR TITLE
chore: add GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,39 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: dist
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Currently, two official plugins are available:
    npm run preview
    ```
 
+## GitHub Pages Deployment
+
+This project can be deployed to GitHub Pages using the provided workflow at `.github/workflows/pages.yml`. The built site will be available at `https://<your-github-username>.github.io/guess-the-model/` once the workflow runs.
+
 ## Audio Assets
 
 Place your sound effects and background music in the `public/audio` directory.

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,5 +3,6 @@ import react from '@vitejs/plugin-react';
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: '/guess-the-model/',
   plugins: [react()],
 });


### PR DESCRIPTION
## Summary
- configure Vite base path for GitHub Pages
- document GitHub Pages deployment
- add workflow to build and deploy to GitHub Pages

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Unable to resolve modules and parsing errors)*
- `npm run build` *(fails: stats.ts Parameter declaration expected)*

------
https://chatgpt.com/codex/tasks/task_e_68ad4ff2850c8326b5730836ce5e419d