### PR TITLE
fix router base path

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,7 @@ import App from './App.tsx';
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename={import.meta.env.BASE_URL}>
       <App />
     </BrowserRouter>
   </StrictMode>,


### PR DESCRIPTION
## Summary
- ensure router honors deployment subdirectory by using Vite base URL as BrowserRouter basename

## Testing
- `npm run lint`
- `npm run test:e2e` (fails: game.cy.ts has 2 failing tests)


------
https://chatgpt.com/codex/tasks/task_e_68ad56430f0c83269f6f13f7913b9852