### PR TITLE
Add About page with project details

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import Home from './routes/Home.tsx';
 import StatsPage from './routes/StatsPage.tsx';
 import Game from './routes/Game.tsx';
+import About from './routes/About.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
 function App(): ReactElement {
@@ -97,6 +98,7 @@ function App(): ReactElement {
             >
               <li><Link to="/" onClick={() => setMenuOpen(false)}>Home</Link></li>
               <li><Link to="/stats" onClick={() => setMenuOpen(false)}>Stats</Link></li>
+              <li><Link to="/about" onClick={() => setMenuOpen(false)}>About</Link></li>
               <li className="lg:hidden">
                 <button
                   type="button"
@@ -144,6 +146,7 @@ function App(): ReactElement {
           <Route path="/classic" element={<Game mode="classic" />} />
           <Route path="/quiz" element={<Game mode="quiz" />} />
           <Route path="/stats" element={<StatsPage />} />
+          <Route path="/about" element={<About />} />
         </Routes>
       </main>
     </div>

--- a/src/routes/About.tsx
+++ b/src/routes/About.tsx
@@ -1,0 +1,18 @@
+import type { ReactElement } from 'react';
+
+function About(): ReactElement {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-4 p-8 text-center text-white">
+      <h1 className="text-3xl font-bold">About Guess the Model</h1>
+      <p className="max-w-xl">
+        Guess the Model is a playful web game built in August 2025. Each round shows an AI-generated
+        artwork and challenges you to guess which generative art model produced it. The game ships
+        with five popular generators—DALL·E 3, Midjourney v6, Stable Diffusion 3,
+        Ideogram 2, and Adobe Firefly 2. Can you spot the subtle differences in style and pick the
+        right model?
+      </p>
+    </div>
+  );
+}
+
+export default About;


### PR DESCRIPTION
## Summary
- add About route that outlines what Guess the Model is about
- link to the About page from the nav menu

## Testing
- `npm run lint`
- `npm run test:e2e` *(fails: missing Xvfb)*

------
https://chatgpt.com/codex/tasks/task_e_68adc536e3dc83269cc96a42a5c9b162