### PR TITLE
Add bot-aware About section and footer menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "daisyui": "^5.0.50",
+        "isbot": "^5.1.30",
         "react": "^19.1.1",
         "react-confetti": "^6.4.0",
         "react-dom": "^19.1.1",
@@ -5960,6 +5961,15 @@
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/isbot": {
+      "version": "5.1.30",
+      "resolved": "https://registry.npmjs.org/isbot/-/isbot-5.1.30.tgz",
+      "integrity": "sha512-3wVJEonAns1OETX83uWsk5IAne2S5zfDcntD2hbtU23LelSqNXzXs9zKjMPOLMzroCgIjCfjYAEHrd2D6FOkiA==",
+      "license": "Unlicense",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/isexe": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "daisyui": "^5.0.50",
+    "isbot": "^5.1.30",
     "react": "^19.1.1",
     "react-confetti": "^6.4.0",
     "react-dom": "^19.1.1",
@@ -25,6 +26,7 @@
     "@types/react-dom": "^19.1.7",
     "@vitejs/plugin-react": "^5.0.0",
     "autoprefixer": "^10.4.21",
+    "cypress": "^15.0.0",
     "eslint": "^8.57.1",
     "eslint-config-airbnb": "^19.0.4",
     "eslint-import-resolver-typescript": "^4.4.4",
@@ -35,11 +37,10 @@
     "eslint-plugin-react-refresh": "^0.4.20",
     "globals": "^16.3.0",
     "postcss": "^8.5.6",
+    "start-server-and-test": "^2.0.13",
     "tailwindcss": "^3.4.4",
     "typescript": "~5.8.3",
     "typescript-eslint": "^8.39.1",
-    "vite": "^7.1.2",
-    "cypress": "^15.0.0",
-    "start-server-and-test": "^2.0.13"
+    "vite": "^7.1.2"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -13,6 +13,7 @@ import {
 import Home from './routes/Home.tsx';
 import StatsPage from './routes/StatsPage.tsx';
 import Game from './routes/Game.tsx';
+import Footer from './components/Footer.tsx';
 import playSound, { playMusic, setMusicEnabled, setSfxEnabled } from './audio.ts';
 
 function App(): ReactElement {
@@ -146,6 +147,12 @@ function App(): ReactElement {
           <Route path="/stats" element={<StatsPage />} />
         </Routes>
       </main>
+      <Footer
+        musicOn={musicOn}
+        sfxOn={sfxOn}
+        toggleMusic={toggleMusic}
+        toggleSfx={toggleSfx}
+      />
     </div>
   );
 }

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,0 +1,41 @@
+import { Link } from 'react-router-dom';
+import type { ReactElement } from 'react';
+
+interface FooterProps {
+  musicOn: boolean;
+  sfxOn: boolean;
+  toggleMusic: () => void;
+  toggleSfx: () => void;
+}
+
+function Footer({
+  musicOn,
+  sfxOn,
+  toggleMusic,
+  toggleSfx,
+}: FooterProps): ReactElement {
+  return (
+    <footer className="bg-[#0b1444] text-white">
+      <ul className="millionaire-menu menu flex w-full justify-center gap-4 p-2">
+        <li>
+          <Link to="/">Home</Link>
+        </li>
+        <li>
+          <Link to="/stats">Stats</Link>
+        </li>
+        <li>
+          <button type="button" onClick={toggleMusic} className="px-4 py-2 text-sm">
+            Music: {musicOn ? 'On' : 'Off'}
+          </button>
+        </li>
+        <li>
+          <button type="button" onClick={toggleSfx} className="px-4 py-2 text-sm">
+            SFX: {sfxOn ? 'On' : 'Off'}
+          </button>
+        </li>
+      </ul>
+    </footer>
+  );
+}
+
+export default Footer;

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -1,8 +1,15 @@
 import { Link } from 'react-router-dom';
-import type { ReactElement } from 'react';
+import { useEffect, useState, type ReactElement } from 'react';
+import { isbot } from 'isbot';
 import logo from '../assets/logo.png';
 
 function Home(): ReactElement {
+  const [isCrawler, setIsCrawler] = useState(false);
+
+  useEffect(() => {
+    setIsCrawler(isbot(navigator.userAgent));
+  }, []);
+
   return (
     <div className="flex h-full w-full flex-col items-center justify-center gap-4 text-center text-white">
       <div className="logo-animation mb-4 w-96">
@@ -15,6 +22,16 @@ function Home(): ReactElement {
         <Link to="/quiz" className="millionaire-button">
           Quiz
         </Link>
+      </div>
+      <div className="mt-12 w-full max-w-prose px-4">
+        <details open={isCrawler}>
+          <summary className="cursor-pointer text-lg font-bold">About</summary>
+          <p className="mt-2 text-sm">
+            Guess the Model is an interactive quiz where players try to identify
+            which AI model produced a given answer. Test your intuition and learn
+            how different models respond to the same questions.
+          </p>
+        </details>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add About section to home page that expands for bots using `isbot`
- detect crawlers via new `isbot` dependency
- add site-wide footer mirroring main menu

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adc69307a88326a241f9c0a4fee939